### PR TITLE
Add nullability for validate() error result and better typing with tagged union for ValidationResult<>

### DIFF
--- a/joi.d.ts
+++ b/joi.d.ts
@@ -194,14 +194,18 @@ interface OptionalSchema {
   [IS_REQUIRED]: false
 }
 
+export type AbstractSchemaValidationCallback<
+    Value
+> = (err: ValidationError | null, value: Value) => void;
+
 interface AbstractSchema<Schema extends AbstractSchema<any, any> = any, Value = any> extends JoiObject {
   schemaType: string
   [VALUE]: Value
 
   /** Validates a value using the schema and options. */
   validate (value: any, options?: ValidationOptions): ValidationResult<Value>
-  validate (value: any, callback: (err: ValidationError | null, value: Value) => void): void
-  validate (value: any, options: ValidationOptions, callback: (err: ValidationError | null, value: Value) => void): void
+  validate (value: any, callback: AbstractSchemaValidationCallback<Value>): void
+  validate (value: any, options: ValidationOptions, callback: AbstractSchemaValidationCallback<Value>): void
 
   /** Whitelists a value */
   allow<T extends AnyType[]> (values: T): SchemaType<Schema, Value | T[number]>


### PR DESCRIPTION
Since everybody uses `strictNullChecks` and `validate()` may not always return a fully-fledged `ValidationError`, it should be unionized with `null`. Moreover, we can use this peculiarity to make `ValidationResult` a tagged union that increases strong typing as you may now check returned `ValidationResult` with a type guard and get the proper type of `value` accordingly. If there happened `ValidationError`, `value` gets `unknown` type, because we are not sure of its type (it could be deserialized). 

This is a breaking change, but I'd rather call it a bug fix, because previously `value` had the type it could not always have (namely `SchemaValue<Schema>`).

Unfortunately, currently `TypeScript` is not able to provide arguments type inference if `[AbstractSchema]ValidationCallback<>` is declared as a tagged union of functions or overloaded interface. I could change the type of `value` argument of `callback` to be `unknown`, but this way clients would have to always cast it to `SchemaValue<typeof schema>` which is ugly, so I'd like to hear your proposals.

Demo of new `ValidationResult<>` implementation (notice that the users may use type guards only by `ValidationResult['error']`, which is normal).
<details>
<summary>View demo</summary>

![joi-test](https://user-images.githubusercontent.com/36276403/55983871-c5891c80-5ca4-11e9-9f7f-be01dfa45e23.gif)


</details>

