### PR TITLE
Improve validation result error checking

### DIFF
--- a/src/lib/joi.ts
+++ b/src/lib/joi.ts
@@ -39,9 +39,21 @@ export interface DefaultFunctionWithDescription<T> extends DefaultFunction<T> {
   description: string
 }
 
-export interface ValidationResult<T> extends Pick<Promise<T>, 'then' | 'catch'> {
-  error: Joi.ValidationError | null;
+export interface ValidationResultSuccess<T> extends Pick<Promise<T>, 'then' | 'catch'> {
+  error: null;
   value: T;
+}
+
+export interface ValidationResultError<T> {
+  error: Joi.ValidationError;
+  // Make sure the keys exist so destructing works
+  value: T extends { [key: string]: any } ? { [key in keyof T]: undefined } : undefined;
+}
+
+export interface ValidationResultUnchecked<T> {
+  error: Joi.ValidationError;
+  // Make sure the keys exist so destructing works and change the values to possibly undefined
+  value: T extends { [key: string]: any } ? { [key in keyof T]?: T[key] } : T;
 }
 
 export type ValidationCallback<T> = (err: Joi.ValidationError, value: T) => void

--- a/src/lib/joi.ts
+++ b/src/lib/joi.ts
@@ -56,6 +56,11 @@ export interface ValidationResultUnchecked<T> {
   value: T extends { [key: string]: any } ? { [key in keyof T]?: T[key] } : T;
 }
 
+export type ValidationResult<T> =
+  | ValidationResultUnchecked<T>
+  | ValidationResultError<T>
+  | ValidationResultSuccess<T>;
+
 export type ValidationCallback<T> = (err: Joi.ValidationError, value: T) => void
 
 export interface Extension {


### PR DESCRIPTION
One thing I'd like to enforce is to check for an error. If for some reason a developer forgets to check the error, the value of the `Joi#validate(..)` call happily returns a properly typed value object.

Before this change:
```
const mySchema = Joi.object().keys({ foo: Joi.string().required() }).required();
const result = Joi.validate(request.body, mySchema);
// result.value.foo is simply available which may cause issues if the validation failed but not checked
```

After this change:
```
const mySchema = Joi.object().keys({ foo: Joi.string().required() }).required();
const result = Joi.validate(request.body, mySchema);
// result.value.foo errors with `Object is possibly 'null'`.
```

This should be fixed by:
```
const mySchema = Joi.object().keys({ foo: Joi.string().required() }).required();
const result = Joi.validate(request.body, mySchema);

if (result.error) {
  // result.error available; result.value.foo undefined
} else {
  // result.value.foo available
}
```

One thing which doesn't work yet (but probably because of reasons tsc people might know):
```
const mySchema = Joi.object().keys({ foo: Joi.string().required() }).required();
const { error, value: { foo } } = Joi.validate(request.body, mySchema);

if (error) {
  // error; foo is string | undefined but should be undefined
} else {
  // foo is not properly infered but is string | undefined and should be string
}
```

The nice thing is that you don't have to add redundant check to see if props on the value are correct: the compiler is smart enough, if error is null, to infer props on value will be correct (except for the destructure use case).

It's seems, in case of an error, value is actually not null or undefined, but still some object so I made some last minute changes to address this. Also, I wasn't aware of the promise api and for the rest I don't know if this possibly breaks any use cases.

Let me know and feel free to make some changes to this merge request yourself. For example: I don't know what kind of types are possible in the value object.